### PR TITLE
chore: update Node.js, pnpm, and GitHub Actions to latest versions

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -7,10 +7,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v4
       with:
         version: 10.26.2
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         node-version: [24]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/version-or-publish.yml
+++ b/.github/workflows/version-or-publish.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         node-version: [24]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       # Uncomment this if you're using pnpm
       # - name: Install pnpm
-      #   uses: pnpm/action-setup@v2
+      #   uses: pnpm/action-setup@v4
       #   with:
-      #     version: 8
+      #     version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
           cache: npm # or pnpm
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary

This PR updates Node.js, pnpm, and GitHub Actions to their latest versions to ensure compatibility with the latest features, security patches, and best practices.

## Changes

### Version Updates

- **Node.js**: 16 → 24 (latest LTS)
- **pnpm**: 8 → 10
- **actions/checkout**: v3 → v6
- **actions/setup-node**: v3 → v6
- **pnpm/action-setup**: v2 → v4

### Files Modified

- `README.md`: Updated example workflow with latest versions
- `.github/workflows/ci.yml`: Updated checkout action
- `.github/workflows/version-or-publish.yml`: Updated checkout action
- `.github/actions/setup-pnpm/action.yml`: Updated pnpm and setup-node actions

## Motivation

- Node.js 16 has reached end-of-life
- GitHub Actions v3 versions are outdated and missing newer features
- Keeping dependencies up-to-date ensures better security and performance
- Node 24 compatibility is required for future GitHub Actions runner updates

## Testing

- ✅ Linting and type checking passed
- ✅ All workflows use consistent versions

---

🤖 Generated with [Claude Code](https://claude.ai/code)
